### PR TITLE
우드 - 카드덱 구현 및 2-2 피드백 반영

### DIFF
--- a/PokerGameApp/PokerGameApp.xcodeproj/project.pbxproj
+++ b/PokerGameApp/PokerGameApp.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		63438CA029BF12FD000873DD /* PokerGameAppUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63438C9F29BF12FD000873DD /* PokerGameAppUITests.swift */; };
 		63438CA229BF12FD000873DD /* PokerGameAppUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63438CA129BF12FD000873DD /* PokerGameAppUITestsLaunchTests.swift */; };
 		63438CAF29C172F7000873DD /* Card.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63438CAE29C172F7000873DD /* Card.swift */; };
+		63438CB129C2F078000873DD /* CardDeck.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63438CB029C2F078000873DD /* CardDeck.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -51,6 +52,7 @@
 		63438C9F29BF12FD000873DD /* PokerGameAppUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PokerGameAppUITests.swift; sourceTree = "<group>"; };
 		63438CA129BF12FD000873DD /* PokerGameAppUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PokerGameAppUITestsLaunchTests.swift; sourceTree = "<group>"; };
 		63438CAE29C172F7000873DD /* Card.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Card.swift; sourceTree = "<group>"; };
+		63438CB029C2F078000873DD /* CardDeck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardDeck.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -105,6 +107,7 @@
 				63438C8029BF12FB000873DD /* SceneDelegate.swift */,
 				63438C8229BF12FB000873DD /* GameViewController.swift */,
 				63438CAE29C172F7000873DD /* Card.swift */,
+				63438CB029C2F078000873DD /* CardDeck.swift */,
 				63438C8429BF12FB000873DD /* Main.storyboard */,
 				63438C8729BF12FD000873DD /* Assets.xcassets */,
 				63438C8929BF12FD000873DD /* LaunchScreen.storyboard */,
@@ -262,6 +265,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				63438C8329BF12FB000873DD /* GameViewController.swift in Sources */,
+				63438CB129C2F078000873DD /* CardDeck.swift in Sources */,
 				63438C7F29BF12FB000873DD /* AppDelegate.swift in Sources */,
 				63438C8129BF12FB000873DD /* SceneDelegate.swift in Sources */,
 				63438CAF29C172F7000873DD /* Card.swift in Sources */,

--- a/PokerGameApp/PokerGameApp/Card.swift
+++ b/PokerGameApp/PokerGameApp/Card.swift
@@ -3,7 +3,7 @@ struct Card {
     // 클래스보다 접근이나 메모리 관리가 효율적이기 때문입니다.
     
     // enum 타입으로 설정한 이유는 가독성면에서 좋기 때문입니다.
-    enum Suit:String, CustomStringConvertible {
+    enum Suit:String, CustomStringConvertible, CaseIterable {
         case spade = "♠",
              heart = "♥",
              clover = "♣",
@@ -14,7 +14,7 @@ struct Card {
         }
     }
     
-    enum Rank:Int, CustomStringConvertible {
+    enum Rank:Int, CustomStringConvertible, CaseIterable {
         case ace = 1,
              two,
              three,

--- a/PokerGameApp/PokerGameApp/Card.swift
+++ b/PokerGameApp/PokerGameApp/Card.swift
@@ -3,14 +3,18 @@ struct Card {
     // 클래스보다 접근이나 메모리 관리가 효율적이기 때문입니다.
     
     // enum 타입으로 설정한 이유는 가독성면에서 좋기 때문입니다.
-    enum Suit:String {
+    enum Suit:String, CustomStringConvertible {
         case spade = "♠",
              heart = "♥",
              clover = "♣",
              diamond = "♦"
+        
+        var description: String {
+            return self.rawValue
+        }
     }
     
-    enum Rank:Int {
+    enum Rank:Int, CustomStringConvertible {
         case ace = 1,
              two,
              three,
@@ -24,6 +28,10 @@ struct Card {
              jack,
              queen,
              king
+        
+        var description: String {
+            return "\(self.rawValue)"
+        }
     }
     
     private let suit:Suit
@@ -33,21 +41,10 @@ struct Card {
         self.suit = suit
         self.rank = rank
     }
-    
-    func showInformation() -> String {
-        var stringRank = ""
-        switch self.rank {
-        case .ace:
-            stringRank = "A"
-        case .jack:
-            stringRank = "J"
-        case .queen:
-            stringRank = "Q"
-        case .king:
-            stringRank = "K"
-        default:
-            stringRank = String(self.rank.rawValue)
-        }
-        return self.suit.rawValue + stringRank
+}
+
+extension Card:CustomStringConvertible {
+    var description: String {
+        return self.suit.description + self.rank.description
     }
 }

--- a/PokerGameApp/PokerGameApp/Card.swift
+++ b/PokerGameApp/PokerGameApp/Card.swift
@@ -3,6 +3,7 @@ struct Card {
     // 클래스보다 접근이나 메모리 관리가 효율적이기 때문입니다.
     
     // enum 타입으로 설정한 이유는 가독성면에서 좋기 때문입니다.
+    // CaseIterable 채택 이유: CardDeck 구조체에서 카드 초기화에 활용
     enum Suit:String, CustomStringConvertible, CaseIterable {
         case spade = "♠",
              heart = "♥",

--- a/PokerGameApp/PokerGameApp/Card.swift
+++ b/PokerGameApp/PokerGameApp/Card.swift
@@ -4,16 +4,26 @@ struct Card {
     
     // enum 타입으로 설정한 이유는 가독성면에서 좋기 때문입니다.
     enum Suit:String {
-        case spade = "♠"
-        case heart = "♥"
-        case clover = "♣"
-        case diamond = "♦"
+        case spade = "♠",
+             heart = "♥",
+             clover = "♣",
+             diamond = "♦"
     }
     
     enum Rank:Int {
-        case two = 2, three, four, five, six, seven, eight, nine, ten
-        case ace = 1
-        case jack = 11, queen, king
+        case ace = 1,
+             two,
+             three,
+             four,
+             five,
+             six,
+             seven,
+             eight,
+             nine,
+             ten,
+             jack,
+             queen,
+             king
     }
     
     private let suit:Suit

--- a/PokerGameApp/PokerGameApp/CardDeck.swift
+++ b/PokerGameApp/PokerGameApp/CardDeck.swift
@@ -1,8 +1,11 @@
+// 덱은 미션을 끝까지 봤을 때 하나만 구현해도 된다고 생각하였고
+// 상속이나 재사용성을 활용할 경우가 없다 생각하여 구조체로 선언
 struct CardDeck {
     private var deck:[Card] = []
     
+    // 초기화와 동시에 54장의 카드를 가지도록 의도하여 reset 메소드를 호출 함
     init() {
-        getAllCards()
+        reset()
     }
     
     func count() -> Int {
@@ -21,16 +24,11 @@ struct CardDeck {
     }
     
     mutating func reset() {
-        getAllCards()
-    }
-
-    mutating func getAllCards() {
-        var cards:[Card] = []
+        deck = []
         for suit in Card.Suit.allCases {
             for rank in Card.Rank.allCases {
-                cards.append(Card(suit: suit, rank: rank))
+                deck.append(Card(suit: suit, rank: rank))
             }
         }
-        deck = cards
     }
 }

--- a/PokerGameApp/PokerGameApp/CardDeck.swift
+++ b/PokerGameApp/PokerGameApp/CardDeck.swift
@@ -12,14 +12,26 @@ struct CardDeck {
         return deck.count
     }
     
-    mutating func shuffle() {
-        for index in 0..<deck.count-1 {
-            let switchIndex = Int.random(in: index..<deck.count)
-            deck.swapAt(index, switchIndex)
+    // 덱에 카드가 한장이거나 없을때 예외처리
+    mutating func shuffle() throws {
+        switch count() {
+        case 0:
+            throw CardDeckError.isEmpty
+        case 1:
+            throw CardDeckError.OneCard
+        default:
+            for index in 0..<deck.count-1 {
+                let switchIndex = Int.random(in: index..<deck.count)
+                deck.swapAt(index, switchIndex)
+            }
         }
     }
 
+    // 덱에 카드가 없을 때 예외처리
     mutating func removeOne() throws -> Card {
+        guard count() != 0 else {
+            throw CardDeckError.isEmpty
+        }
         return deck.removeLast()
     }
     
@@ -30,5 +42,14 @@ struct CardDeck {
                 deck.append(Card(suit: suit, rank: rank))
             }
         }
+    }
+}
+
+// 에러 선언부는 메소드와 분리시켜 선언하는게 가독성이 좋다고 판단하여 확장부에 작성
+extension CardDeck {
+    // CardDeck에서만 사용하기에 Nested Enum Type으로 선언
+    enum CardDeckError:Error {
+        case isEmpty
+        case OneCard
     }
 }

--- a/PokerGameApp/PokerGameApp/CardDeck.swift
+++ b/PokerGameApp/PokerGameApp/CardDeck.swift
@@ -1,0 +1,36 @@
+struct CardDeck {
+    private var deck:[Card] = []
+    
+    init() {
+        getAllCards()
+    }
+    
+    func count() -> Int {
+        return deck.count
+    }
+    
+    mutating func shuffle() {
+        for index in 0..<deck.count-1 {
+            let switchIndex = Int.random(in: index..<deck.count)
+            deck.swapAt(index, switchIndex)
+        }
+    }
+
+    mutating func removeOne() throws -> Card {
+        return deck.removeLast()
+    }
+    
+    mutating func reset() {
+        getAllCards()
+    }
+
+    mutating func getAllCards() {
+        var cards:[Card] = []
+        for suit in Card.Suit.allCases {
+            for rank in Card.Rank.allCases {
+                cards.append(Card(suit: suit, rank: rank))
+            }
+        }
+        deck = cards
+    }
+}

--- a/PokerGameApp/PokerGameApp/CardDeck.swift
+++ b/PokerGameApp/PokerGameApp/CardDeck.swift
@@ -2,19 +2,19 @@
 // 상속이나 재사용성을 활용할 경우가 없다 생각하여 구조체로 선언
 struct CardDeck {
     private var deck:[Card] = []
-    
+    // count메소드 대신 편리성 및 중복 메소드 없애기 위해 계산 프로퍼티를 사용
+    var count:Int {
+        return deck.count
+    }
+
     // 초기화와 동시에 54장의 카드를 가지도록 의도하여 reset 메소드를 호출 함
     init() {
         reset()
     }
     
-    func count() -> Int {
-        return deck.count
-    }
-    
     // 덱에 카드가 한장이거나 없을때 예외처리
     mutating func shuffle() throws {
-        switch count() {
+        switch count {
         case 0:
             throw CardDeckError.isEmpty
         case 1:
@@ -29,7 +29,7 @@ struct CardDeck {
 
     // 덱에 카드가 없을 때 예외처리
     mutating func removeOne() throws -> Card {
-        guard count() != 0 else {
+        guard deck.count > 0 else {
             throw CardDeckError.isEmpty
         }
         return deck.removeLast()
@@ -45,11 +45,10 @@ struct CardDeck {
     }
 }
 
-// 에러 선언부는 메소드와 분리시켜 선언하는게 가독성이 좋다고 판단하여 확장부에 작성
-extension CardDeck {
-    // CardDeck에서만 사용하기에 Nested Enum Type으로 선언
-    enum CardDeckError:Error {
+// 오류처리시 GameViewController에서 사용해야하기에
+// Nested Enum -> Enum으로 수정
+enum CardDeckError:Error {
         case isEmpty
         case OneCard
-    }
 }
+

--- a/PokerGameApp/PokerGameApp/GameViewController.swift
+++ b/PokerGameApp/PokerGameApp/GameViewController.swift
@@ -13,6 +13,15 @@ class GameViewController: UIViewController {
         for i in 0..<7 {
             let cardUI = makeCardUI(x: interval + (interval + width) * CGFloat(i), y: positionY)
         }
+        
+        var deck = CardDeck()
+        shuffle(deck: &deck)
+        for i in 0..<54 {
+            guard let card = removeOne(deck: &deck) else {
+                return
+            }
+            print(card)
+        }
     }
     
     private func setBackground(imageName: String) {
@@ -33,5 +42,28 @@ class GameViewController: UIViewController {
         self.view.addSubview(cardUI)
         
         return cardUI
+    }
+    
+    private func shuffle(deck:inout CardDeck) {
+        do {
+            try deck.shuffle()
+        } catch {
+            print(error)
+        }
+    }
+    
+    private func removeOne(deck: inout CardDeck) -> Card? {
+        var card:Card?
+        do {
+            card = try deck.removeOne()
+        } catch CardDeckError.isEmpty {
+            print("Deck is Empty")
+        } catch {
+            print("\(error)")
+        }
+        guard card != nil else {
+            return nil
+        }
+        return card!
     }
 }

--- a/PokerGameApp/PokerGameApp/GameViewController.swift
+++ b/PokerGameApp/PokerGameApp/GameViewController.swift
@@ -6,7 +6,7 @@ class GameViewController: UIViewController {
         setBackground(imageName: "backgroundImage")
         
         let interval = CGFloat(2.6)
-        let positionY = CGFloat(54)
+        let positionY = CGFloat(59)
         let count = CGFloat(7)
         let totalInterval = interval * count
         let width = (UIScreen.main.bounds.size.width - totalInterval) / count
@@ -31,6 +31,7 @@ class GameViewController: UIViewController {
         let height = width * 1.27
         cardUI.frame = CGRect(x: x, y: y, width: width, height: height)
         self.view.addSubview(cardUI)
+        
         return cardUI
     }
 }

--- a/PokerGameApp/PokerGameApp/GameViewController.swift
+++ b/PokerGameApp/PokerGameApp/GameViewController.swift
@@ -5,23 +5,23 @@ class GameViewController: UIViewController {
         super.viewDidLoad()
         setBackground(imageName: "backgroundImage")
         
-        let cardInterval = CGFloat(2.6)
-        let cardPositionY = CGFloat(54)
-        let cardWidth = UIScreen.main.bounds.size.width / 7 - 3
-        let cardPatternWidth = cardWidth + cardInterval
+        let interval = CGFloat(2.6)
+        let positionY = CGFloat(54)
+        let count = CGFloat(7)
+        let totalInterval = interval * count
+        let width = (UIScreen.main.bounds.size.width - totalInterval) / count
         for i in 0..<7 {
-            let cardUI = makeCardUI(x: cardInterval + (cardInterval + cardWidth) * CGFloat(i), y: cardPositionY)
-            self.view.addSubview(cardUI)
+            let cardUI = makeCardUI(x: interval + (interval + width) * CGFloat(i), y: positionY)
         }
     }
     
-    func setBackground(imageName: String) {
+    private func setBackground(imageName: String) {
         if let image = UIImage(named: imageName) {
             self.view.backgroundColor = UIColor(patternImage: image)
         }
     }
     
-    func makeCardUI(x:CGFloat, y:CGFloat) -> UIImageView {
+    private func makeCardUI(x:CGFloat, y:CGFloat) -> UIImageView {
         var cardUI = UIImageView()
         if let deck = UIImage(named: "card-back") {
             cardUI = UIImageView(image: deck)
@@ -30,6 +30,7 @@ class GameViewController: UIViewController {
         let width = UIScreen.main.bounds.size.width / 7 - 3
         let height = width * 1.27
         cardUI.frame = CGRect(x: x, y: y, width: width, height: height)
+        self.view.addSubview(cardUI)
         return cardUI
     }
 }


### PR DESCRIPTION
## 주요 작업
- 카드덱 구현
- 오류 처리 구문 shuffle / removeOne 메소드에 추가
## 학습 내용
- CustomStringConvertible 프로토콜
- try - catch문 Error-Handling
## 고민 사항
- 공식문서나 많은 블로그에서 CustomStringConvertible 프로토콜의 **작성 위치를 extension에 작성**하는 경우가 많은데   
가독성면에서 좋은 점과 주요 메소드들과 분리시켜 작성시키기 위해서라는데
   다른 이유도 있는지 궁금합니다!
- inout파라미터를 사용하지 않고 do-catch문을 사용하려 시도했지만 실패해 사용했습니다. 
## 실행 결과
<img width="518" alt="스크린샷 2023-03-20 오전 11 35 03" src="https://user-images.githubusercontent.com/84387335/226233675-4cf671d0-92d9-4f2e-bbaf-fba7109bcfa9.png">
