### PR TITLE
[Effie] 카드 덱 구현 및 테스트 코드 추가

### DIFF
--- a/PokerGameApp/PokerGameApp.xcodeproj/project.pbxproj
+++ b/PokerGameApp/PokerGameApp.xcodeproj/project.pbxproj
@@ -13,6 +13,8 @@
 		F42DDF1029BEB66C00B0DFBE /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = F42DDF0E29BEB66C00B0DFBE /* Main.storyboard */; };
 		F42DDF1229BEB66D00B0DFBE /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F42DDF1129BEB66D00B0DFBE /* Assets.xcassets */; };
 		F42DDF1529BEB66D00B0DFBE /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = F42DDF1329BEB66D00B0DFBE /* LaunchScreen.storyboard */; };
+		F442291129C807FE00CBF0CD /* CardDeck.swift in Sources */ = {isa = PBXBuildFile; fileRef = F442291029C807FE00CBF0CD /* CardDeck.swift */; };
+		F442291329C8082A00CBF0CD /* Array_Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = F442291229C8082A00CBF0CD /* Array_Extension.swift */; };
 		F4E1AD5629C1DF0900E999F3 /* OutputManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4E1AD5529C1DF0900E999F3 /* OutputManager.swift */; };
 		F4E1AD5829C1DF1400E999F3 /* Card.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4E1AD5729C1DF1400E999F3 /* Card.swift */; };
 /* End PBXBuildFile section */
@@ -26,6 +28,8 @@
 		F42DDF1129BEB66D00B0DFBE /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		F42DDF1429BEB66D00B0DFBE /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		F42DDF1629BEB66D00B0DFBE /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		F442291029C807FE00CBF0CD /* CardDeck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardDeck.swift; sourceTree = "<group>"; };
+		F442291229C8082A00CBF0CD /* Array_Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Array_Extension.swift; sourceTree = "<group>"; };
 		F4E1AD5529C1DF0900E999F3 /* OutputManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OutputManager.swift; sourceTree = "<group>"; };
 		F4E1AD5729C1DF1400E999F3 /* Card.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Card.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -63,6 +67,8 @@
 				F42DDF0829BEB66C00B0DFBE /* AppDelegate.swift */,
 				F42DDF0A29BEB66C00B0DFBE /* SceneDelegate.swift */,
 				F42DDF0C29BEB66C00B0DFBE /* ViewController.swift */,
+				F442291029C807FE00CBF0CD /* CardDeck.swift */,
+				F442291229C8082A00CBF0CD /* Array_Extension.swift */,
 				F4E1AD5729C1DF1400E999F3 /* Card.swift */,
 				F4E1AD5529C1DF0900E999F3 /* OutputManager.swift */,
 				F42DDF0E29BEB66C00B0DFBE /* Main.storyboard */,
@@ -144,10 +150,12 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F442291129C807FE00CBF0CD /* CardDeck.swift in Sources */,
 				F42DDF0D29BEB66C00B0DFBE /* ViewController.swift in Sources */,
 				F42DDF0929BEB66C00B0DFBE /* AppDelegate.swift in Sources */,
 				F4E1AD5829C1DF1400E999F3 /* Card.swift in Sources */,
 				F4E1AD5629C1DF0900E999F3 /* OutputManager.swift in Sources */,
+				F442291329C8082A00CBF0CD /* Array_Extension.swift in Sources */,
 				F42DDF0B29BEB66C00B0DFBE /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/PokerGameApp/PokerGameApp.xcodeproj/project.pbxproj
+++ b/PokerGameApp/PokerGameApp.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		F42DDF1529BEB66D00B0DFBE /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = F42DDF1329BEB66D00B0DFBE /* LaunchScreen.storyboard */; };
 		F442291129C807FE00CBF0CD /* CardDeck.swift in Sources */ = {isa = PBXBuildFile; fileRef = F442291029C807FE00CBF0CD /* CardDeck.swift */; };
 		F442291329C8082A00CBF0CD /* Array_Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = F442291229C8082A00CBF0CD /* Array_Extension.swift */; };
+		F442291729C80A3000CBF0CD /* PokerGame.swift in Sources */ = {isa = PBXBuildFile; fileRef = F442291629C80A3000CBF0CD /* PokerGame.swift */; };
 		F4E1AD5629C1DF0900E999F3 /* OutputManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4E1AD5529C1DF0900E999F3 /* OutputManager.swift */; };
 		F4E1AD5829C1DF1400E999F3 /* Card.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4E1AD5729C1DF1400E999F3 /* Card.swift */; };
 /* End PBXBuildFile section */
@@ -30,6 +31,7 @@
 		F42DDF1629BEB66D00B0DFBE /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		F442291029C807FE00CBF0CD /* CardDeck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardDeck.swift; sourceTree = "<group>"; };
 		F442291229C8082A00CBF0CD /* Array_Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Array_Extension.swift; sourceTree = "<group>"; };
+		F442291629C80A3000CBF0CD /* PokerGame.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PokerGame.swift; sourceTree = "<group>"; };
 		F4E1AD5529C1DF0900E999F3 /* OutputManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OutputManager.swift; sourceTree = "<group>"; };
 		F4E1AD5729C1DF1400E999F3 /* Card.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Card.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -69,6 +71,7 @@
 				F42DDF0C29BEB66C00B0DFBE /* ViewController.swift */,
 				F442291029C807FE00CBF0CD /* CardDeck.swift */,
 				F442291229C8082A00CBF0CD /* Array_Extension.swift */,
+				F442291629C80A3000CBF0CD /* PokerGame.swift */,
 				F4E1AD5729C1DF1400E999F3 /* Card.swift */,
 				F4E1AD5529C1DF0900E999F3 /* OutputManager.swift */,
 				F42DDF0E29BEB66C00B0DFBE /* Main.storyboard */,
@@ -155,6 +158,7 @@
 				F42DDF0929BEB66C00B0DFBE /* AppDelegate.swift in Sources */,
 				F4E1AD5829C1DF1400E999F3 /* Card.swift in Sources */,
 				F4E1AD5629C1DF0900E999F3 /* OutputManager.swift in Sources */,
+				F442291729C80A3000CBF0CD /* PokerGame.swift in Sources */,
 				F442291329C8082A00CBF0CD /* Array_Extension.swift in Sources */,
 				F42DDF0B29BEB66C00B0DFBE /* SceneDelegate.swift in Sources */,
 			);

--- a/PokerGameApp/PokerGameApp.xcodeproj/project.pbxproj
+++ b/PokerGameApp/PokerGameApp.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		F4226F3429CAA8B4002A0AC3 /* PokerError.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4226F3329CAA8B4002A0AC3 /* PokerError.swift */; };
 		F42DDF0929BEB66C00B0DFBE /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F42DDF0829BEB66C00B0DFBE /* AppDelegate.swift */; };
 		F42DDF0B29BEB66C00B0DFBE /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F42DDF0A29BEB66C00B0DFBE /* SceneDelegate.swift */; };
 		F42DDF0D29BEB66C00B0DFBE /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F42DDF0C29BEB66C00B0DFBE /* ViewController.swift */; };
@@ -21,6 +22,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		F4226F3329CAA8B4002A0AC3 /* PokerError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PokerError.swift; sourceTree = "<group>"; };
 		F42DDF0529BEB66C00B0DFBE /* PokerGameApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PokerGameApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		F42DDF0829BEB66C00B0DFBE /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		F42DDF0A29BEB66C00B0DFBE /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -72,6 +74,7 @@
 				F442291029C807FE00CBF0CD /* CardDeck.swift */,
 				F442291229C8082A00CBF0CD /* Array_Extension.swift */,
 				F442291629C80A3000CBF0CD /* PokerGame.swift */,
+				F4226F3329CAA8B4002A0AC3 /* PokerError.swift */,
 				F4E1AD5729C1DF1400E999F3 /* Card.swift */,
 				F4E1AD5529C1DF0900E999F3 /* OutputManager.swift */,
 				F42DDF0E29BEB66C00B0DFBE /* Main.storyboard */,
@@ -161,6 +164,7 @@
 				F442291729C80A3000CBF0CD /* PokerGame.swift in Sources */,
 				F442291329C8082A00CBF0CD /* Array_Extension.swift in Sources */,
 				F42DDF0B29BEB66C00B0DFBE /* SceneDelegate.swift in Sources */,
+				F4226F3429CAA8B4002A0AC3 /* PokerError.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/PokerGameApp/PokerGameApp/Array_Extension.swift
+++ b/PokerGameApp/PokerGameApp/Array_Extension.swift
@@ -14,13 +14,4 @@ extension Array {
       swapAt(i, randomIndex)
     }
   }
-  
-  private var randomIndex: Int? {
-    (0..<count).randomElement()
-  }
-  
-  mutating func removeRandom() -> Element? {
-    guard let randomIndex = self.randomIndex else { return nil }
-    return self.remove(at: randomIndex)
-  }
 }

--- a/PokerGameApp/PokerGameApp/Array_Extension.swift
+++ b/PokerGameApp/PokerGameApp/Array_Extension.swift
@@ -1,0 +1,26 @@
+//
+//  Array_Extension.swift
+//  PokerGameApp
+//
+//  Created by Effie on 2023/03/20.
+//
+
+import Foundation
+
+extension Array {
+  mutating func myShuffle() {
+    for i in (0..<count).reversed() {
+      guard let randomIndex = (0...i).randomElement() else { break }
+      swapAt(i, randomIndex)
+    }
+  }
+  
+  private var randomIndex: Int? {
+    (0..<count).randomElement()
+  }
+  
+  mutating func removeRandom() -> Element? {
+    guard let randomIndex = self.randomIndex else { return nil }
+    return self.remove(at: randomIndex)
+  }
+}

--- a/PokerGameApp/PokerGameApp/Card.swift
+++ b/PokerGameApp/PokerGameApp/Card.swift
@@ -11,7 +11,7 @@ class Card {
   /// 카드의 문양
   ///
   /// 카드 숫자의 타입과 일관성을 위해서 열거형으로 선언했습니다.
-  enum Shape: CustomStringConvertible {
+  enum Shape: CustomStringConvertible, CaseIterable {
     case spade
     case clove
     case heart
@@ -30,7 +30,7 @@ class Card {
   /// 카드의 숫자
   ///
   /// 카드 숫자는 경우가 많고, 그 경우의 수를 제한할 필요가 있어서 열거형으로 선언했습니다.
-  enum Number: Int, CustomStringConvertible {
+  enum Number: Int, CustomStringConvertible, CaseIterable {
     case ace,
          two,
          three,

--- a/PokerGameApp/PokerGameApp/Card.swift
+++ b/PokerGameApp/PokerGameApp/Card.swift
@@ -11,32 +11,41 @@ class Card {
   /// 카드의 문양
   ///
   /// 카드 숫자의 타입과 일관성을 위해서 열거형으로 선언했습니다.
-  enum Shape: Character {
-    case spade = "\u{2660}"
-    case clove = "\u{2663}"
-    case heart = "\u{2665}"
-    case diamond = "\u{2666}"
+  enum Shape: CustomStringConvertible {
+    case spade
+    case clove
+    case heart
+    case diamond
+    
+    var description: String {
+      switch self {
+      case .spade: return "\u{2660}"
+      case .clove: return "\u{2663}"
+      case .heart: return "\u{2665}"
+      case .diamond: return "\u{2666}"
+      }
+    }
   }
   
   /// 카드의 숫자
   ///
   /// 카드 숫자는 경우가 많고, 그 경우의 수를 제한할 필요가 있어서 열거형으로 선언했습니다.
-  enum Number: Int {
-    case ace = 1,
-         n2,
-         n3,
-         n4,
-         n5,
-         n6,
-         n7,
-         n8,
-         n9,
-         n10,
+  enum Number: Int, CustomStringConvertible {
+    case ace,
+         two,
+         three,
+         four,
+         five,
+         six,
+         seven,
+         eight,
+         nine,
+         ten,
          jack,
          queen,
          king
     
-    var symbol: String {
+    var description: String {
       switch self {
       case .ace: return "A"
       case .jack: return "J"
@@ -56,6 +65,6 @@ class Card {
   }
   
   func info() -> String {
-    "\(shape.rawValue)\(number.symbol)"
+    "\(shape.description)\(number.description)"
   }
 }

--- a/PokerGameApp/PokerGameApp/CardDeck.swift
+++ b/PokerGameApp/PokerGameApp/CardDeck.swift
@@ -33,8 +33,9 @@ struct CardDeck {
     cards.myShuffle()
   }
   
-  mutating func removeOne() -> Card? {
-    cards.isEmpty ? nil : cards.removeLast()
+  mutating func removeOne() throws -> Card {
+    guard cards.isEmpty == false else { throw PokerError.EmptyDeck }
+    return cards.removeLast()
   }
   
   mutating func reset() {

--- a/PokerGameApp/PokerGameApp/CardDeck.swift
+++ b/PokerGameApp/PokerGameApp/CardDeck.swift
@@ -1,0 +1,44 @@
+//
+//  CardDeck.swift
+//  PokerGameApp
+//
+//  Created by Effie on 2023/03/20.
+//
+
+import Foundation
+
+struct CardDeck {
+  private var cards: [Card]
+  
+  var count: Int {
+    cards.count
+  }
+  
+  init() {
+    self.cards = Self.createNewDeck()
+  }
+  
+  private static func createNewDeck() -> [Card] {
+    var newCards = [Card]()
+    for number in Card.Number.allCases {
+      for shape in Card.Shape.allCases {
+        let newCard = Card(shape: shape, number: number)
+        newCards.append(newCard)
+      }
+    }
+    return newCards
+  }
+  
+  mutating func shuffle() {
+    cards.myShuffle()
+  }
+  
+  mutating func removeOne() -> Card? {
+    cards.removeRandom()
+  }
+  
+  mutating func reset() {
+    cards = Self.createNewDeck()
+  }
+}
+

--- a/PokerGameApp/PokerGameApp/CardDeck.swift
+++ b/PokerGameApp/PokerGameApp/CardDeck.swift
@@ -34,11 +34,10 @@ struct CardDeck {
   }
   
   mutating func removeOne() -> Card? {
-    cards.removeRandom()
+    cards.isEmpty ? nil : cards.removeLast()
   }
   
   mutating func reset() {
     cards = Self.createNewDeck()
   }
 }
-

--- a/PokerGameApp/PokerGameApp/PokerError.swift
+++ b/PokerGameApp/PokerGameApp/PokerError.swift
@@ -1,0 +1,12 @@
+//
+//  PokerError.swift
+//  PokerGameApp
+//
+//  Created by Effie on 2023/03/22.
+//
+
+import Foundation
+
+enum PokerError: Error {
+  case EmptyDeck
+}

--- a/PokerGameApp/PokerGameApp/PokerGame.swift
+++ b/PokerGameApp/PokerGameApp/PokerGame.swift
@@ -1,0 +1,43 @@
+//
+//  PokerGame.swift
+//  PokerGameApp
+//
+//  Created by Effie on 2023/03/20.
+//
+
+import Foundation
+
+struct PokerGame {
+  
+  var cardDeck: CardDeck
+  
+  init() {
+    self.cardDeck = CardDeck()
+  }
+  
+  mutating func test(scenario: [String]) {
+    for command in scenario {
+      print(">", terminator: " ")
+      print(command)
+      parseAndProcess(command: command)
+    }
+  }
+  
+  mutating func parseAndProcess(command: String) {
+    switch command {
+    case "카드 초기화":
+      cardDeck.reset()
+      print("카드 전체를 초기화했습니다.")
+      print("총 \(cardDeck.count)장의 카드가 있습니다.\n")
+    case "카드 섞기":
+      cardDeck.shuffle()
+      print("전체 \(cardDeck.count)장의 카드를 섞었습니다.\n")
+    case "카드 하나 뽑기":
+      guard let selected = cardDeck.removeOne() else { break }
+      OutputManager().printInfo(ofCard: selected)
+      print("총 \(cardDeck.count)장의 카드가 남아있습니다.\n")
+    default:
+      return
+    }
+  }
+}

--- a/PokerGameApp/PokerGameApp/PokerGame.swift
+++ b/PokerGameApp/PokerGameApp/PokerGame.swift
@@ -9,7 +9,7 @@ import Foundation
 
 struct PokerGame {
   
-  var cardDeck: CardDeck
+  private var cardDeck: CardDeck
   
   init() {
     self.cardDeck = CardDeck()

--- a/PokerGameApp/PokerGameApp/PokerGame.swift
+++ b/PokerGameApp/PokerGameApp/PokerGame.swift
@@ -33,12 +33,14 @@ struct PokerGame {
       cardDeck.shuffle()
       print("전체 \(cardDeck.count)장의 카드를 섞었습니다.\n")
     case "카드 하나 뽑기":
-      guard let selected = cardDeck.removeOne() else {
+      do {
+        let selected = try cardDeck.removeOne()
+        OutputManager().printInfo(ofCard: selected)
+        print("총 \(cardDeck.count)장의 카드가 남아있습니다.\n")
+      } catch {
         print("덱이 비어있기 때문에 카드를 뽑을 수 없습니다. 덱을 초기화해야 합니다.\n")
         break
       }
-      OutputManager().printInfo(ofCard: selected)
-      print("총 \(cardDeck.count)장의 카드가 남아있습니다.\n")
     default:
       return
     }

--- a/PokerGameApp/PokerGameApp/PokerGame.swift
+++ b/PokerGameApp/PokerGameApp/PokerGame.swift
@@ -33,7 +33,10 @@ struct PokerGame {
       cardDeck.shuffle()
       print("전체 \(cardDeck.count)장의 카드를 섞었습니다.\n")
     case "카드 하나 뽑기":
-      guard let selected = cardDeck.removeOne() else { break }
+      guard let selected = cardDeck.removeOne() else {
+        print("덱이 비어있기 때문에 카드를 뽑을 수 없습니다. 덱을 초기화해야 합니다.\n")
+        break
+      }
       OutputManager().printInfo(ofCard: selected)
       print("총 \(cardDeck.count)장의 카드가 남아있습니다.\n")
     default:

--- a/PokerGameApp/PokerGameApp/ViewController.swift
+++ b/PokerGameApp/PokerGameApp/ViewController.swift
@@ -20,7 +20,6 @@ class ViewController: UIViewController {
     configure()
     addCards(ofRatio: cardAspectRatio, numberOfCard: 7, withInset: 1.0)
     
-//    testCards()
     testGame()
   }
   
@@ -86,6 +85,12 @@ class ViewController: UIViewController {
       "카드 하나 뽑기",
       "카드 하나 뽑기",
     ]
-    game.test(scenario: scenario)
+    
+    let scenario2 = [
+      "카드 초기화",
+      "카드 섞기",
+    ] + Array(repeating: "카드 하나 뽑기", count: 55)
+    
+    game.test(scenario: scenario2)
   }
 }

--- a/PokerGameApp/PokerGameApp/ViewController.swift
+++ b/PokerGameApp/PokerGameApp/ViewController.swift
@@ -72,7 +72,7 @@ class ViewController: UIViewController {
     let diamondJack = Card(shape: .diamond, number: .jack)
     outputManager.printInfo(ofCard: diamondJack)
     
-    let diamondEight = Card(shape: .diamond, number: .n8)
+    let diamondEight = Card(shape: .diamond, number: .eight)
     outputManager.printInfo(ofCard: diamondEight)
   }
 }

--- a/PokerGameApp/PokerGameApp/ViewController.swift
+++ b/PokerGameApp/PokerGameApp/ViewController.swift
@@ -14,13 +14,14 @@ class ViewController: UIViewController {
   private let cardAspectRatio = CGFloat(1.27)
   
   private let cardImage = UIImage(named: "card-back")
-
+  
   override func viewDidLoad() {
     super.viewDidLoad()
     configure()
     addCards(ofRatio: cardAspectRatio, numberOfCard: 7, withInset: 1.0)
     
-    testCards()
+//    testCards()
+    testGame()
   }
   
   private func configure() {
@@ -74,5 +75,17 @@ class ViewController: UIViewController {
     
     let diamondEight = Card(shape: .diamond, number: .eight)
     outputManager.printInfo(ofCard: diamondEight)
+  }
+  
+  private func testGame() {
+    var game = PokerGame()
+    
+    let scenario = [
+      "카드 초기화",
+      "카드 섞기",
+      "카드 하나 뽑기",
+      "카드 하나 뽑기",
+    ]
+    game.test(scenario: scenario)
   }
 }


### PR DESCRIPTION
## 🧩 주요 작업

지난 step 2 PR 제안 사항을 반영했습니다.

- [x]  CustomStringConvertable을 채용해 디버깅 인터페이스들을 description으로 통일
- [x]  일부 속성 rename

카드 덱을 요구사항에 맞게 구현하고, 관련 타입과 extension을 추가했습니다.

- [x]  CardDeck 구조체 구현
- [x]  PokerGame 구조체 구현
- [x]  ViewController에 testGame 메소드 추가 및 호출
- [x]  PokerError 구현

## 🧩 스크린샷

![Mar-22-2023 12-14-28](https://user-images.githubusercontent.com/56967908/226793086-b787d0d2-67dc-4a28-a70d-d1a7b08efa22.gif)

## 🧩 기술 키워드

**구현 과정에서 학습하거나 알게 된 키워드**

- Class and Structure
- ARC
- weak, unowned
- withExtendedLifetime()
- defer
- Swift access control

## 🧩 고민과 해결 과정

### CardDeck, PokerGame 에는 구조체가 좋을까, 클래스가 좋을까?

클래스로 구현해야 할 이유가 없다는 이유로 CardDeck, PokerGame 을 모두 구조체로 선언하였습니다.

### createNewDeck() 구현

52장의 서로 다른 카드를 가진 하나의 덱을 만드는 로직을 이니셜라이저와 deck.reset()에서 공통적으로 사용하게 된다는 것을 파악했습니다 !

createNewDeck() 메소드를 추가해서 로직을 묶고, 이 로직을 private으로 내부에서만 공유하도록 구현했습니다.

### removeOne() 구현

처음에 카드 덱에서 카드를 뽑을 때 랜덤한 코드를 뽑는 방식으로 구현했다가, 작업 중에 게임 설명도 듣고 팀원들의 코드를 보면서 실제로는 당연히(!) 덱 가장 위에 있는 카드, 즉 마지막 카드를 뽑게 된다는 것을 알게 되었습니다. 배열의 removeLast()를 사용해서 마지막 카드를 뽑도록 구현을 수정해두었습니다.

### removeOne이 Card? 를 리턴하도록 할까, 에러를 던지도록 할까?

removeOne을 구현하면서 Array의 removeLast를 사용했는데, 이 인터페이스가 non optional을 리턴한다는 걸 알게 되었고, 배열이 비어 있는 상황은 직접 처리해야 한다는 걸 알게 되었습니다. 

옵셔널(Card?)을 리턴해서 옵셔널 바인딩으로 처리하는 방법과, 에러를 던지고 받아서 처리하는 경우를 생각해 보았는데, 유지 보수하기에 조금 더 깔끔하다고 판단해서 에러 처리 방식으로 구현해두었습니다!