### PR TITLE
Aiden : CardDeck 구현

### DIFF
--- a/PokerGameApp/PokerGameApp.xcodeproj/project.pbxproj
+++ b/PokerGameApp/PokerGameApp.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		2A477CA129C846DF00351B5B /* Card.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A477CA029C846DF00351B5B /* Card.swift */; };
+		2A477CA329CAC44500351B5B /* CardDeck.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A477CA229CAC44500351B5B /* CardDeck.swift */; };
 		2AE2270329BF0EB1006EFBA4 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AE2270229BF0EB1006EFBA4 /* AppDelegate.swift */; };
 		2AE2270529BF0EB1006EFBA4 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AE2270429BF0EB1006EFBA4 /* SceneDelegate.swift */; };
 		2AE2270729BF0EB1006EFBA4 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AE2270629BF0EB1006EFBA4 /* ViewController.swift */; };
@@ -18,6 +19,7 @@
 
 /* Begin PBXFileReference section */
 		2A477CA029C846DF00351B5B /* Card.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Card.swift; sourceTree = "<group>"; };
+		2A477CA229CAC44500351B5B /* CardDeck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardDeck.swift; sourceTree = "<group>"; };
 		2AE226FF29BF0EB1006EFBA4 /* PokerGameApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PokerGameApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		2AE2270229BF0EB1006EFBA4 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		2AE2270429BF0EB1006EFBA4 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -62,6 +64,7 @@
 				2AE2270429BF0EB1006EFBA4 /* SceneDelegate.swift */,
 				2AE2270629BF0EB1006EFBA4 /* ViewController.swift */,
 				2A477CA029C846DF00351B5B /* Card.swift */,
+				2A477CA229CAC44500351B5B /* CardDeck.swift */,
 				2AE2270829BF0EB1006EFBA4 /* Main.storyboard */,
 				2AE2270B29BF0EB4006EFBA4 /* Assets.xcassets */,
 				2AE2270D29BF0EB4006EFBA4 /* LaunchScreen.storyboard */,
@@ -142,6 +145,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				2AE2270729BF0EB1006EFBA4 /* ViewController.swift in Sources */,
+				2A477CA329CAC44500351B5B /* CardDeck.swift in Sources */,
 				2A477CA129C846DF00351B5B /* Card.swift in Sources */,
 				2AE2270329BF0EB1006EFBA4 /* AppDelegate.swift in Sources */,
 				2AE2270529BF0EB1006EFBA4 /* SceneDelegate.swift in Sources */,

--- a/PokerGameApp/PokerGameApp/Card.swift
+++ b/PokerGameApp/PokerGameApp/Card.swift
@@ -12,7 +12,7 @@ struct Card {
     
     // Enum을 사용한 이유는 서로 연관된 데이터라고 생각했습니다
     // 그리고 카드의 경우 문양과 숫자의 갯수가 정해져있고, 이미 정해놓은 입력값만 받고 싶기 때문에 Enum을 사용하였습니다
-    enum Suit: Character, CustomStringConvertible {
+    enum Suit: Character, CustomStringConvertible, CaseIterable {
         case spades = "♠"
         case hearts = "♥"
         case diamonds = "♦"
@@ -22,7 +22,7 @@ struct Card {
             return "\(self.rawValue)"
         }
     }
-    enum Rank: Int, CustomStringConvertible {
+    enum Rank: Int, CustomStringConvertible, CaseIterable {
         case ace = 1,
              two,
              three,
@@ -36,7 +36,6 @@ struct Card {
              jack,
              queen,
              king
-        
         
         var description: String {
             switch self {

--- a/PokerGameApp/PokerGameApp/Card.swift
+++ b/PokerGameApp/PokerGameApp/Card.swift
@@ -23,19 +23,20 @@ struct Card {
         }
     }
     enum Rank: Int, CustomStringConvertible {
-        case ace = 1
-        case two = 2
-        case three = 3
-        case four = 4
-        case five = 5
-        case six = 6
-        case seven = 7
-        case eight = 8
-        case nine = 9
-        case ten = 10
-        case jack = 11
-        case queen = 12
-        case king = 13
+        case ace = 1,
+             two,
+             three,
+             four,
+             five,
+             six,
+             seven,
+             eight,
+             nine,
+             ten,
+             jack,
+             queen,
+             king
+        
         
         var description: String {
             switch self {

--- a/PokerGameApp/PokerGameApp/CardDeck.swift
+++ b/PokerGameApp/PokerGameApp/CardDeck.swift
@@ -16,4 +16,14 @@ struct CardDeck {
         return cards.count
     }
     
+    init() {
+        cards = [Card]()
+        for suit in Card.Suit.allCases {
+            for rank in Card.Rank.allCases {
+                self.cards.append(Card(suit: suit, rank: rank))
+            }
+        }
+        self.newCards = self.cards
+    }
+    
 }

--- a/PokerGameApp/PokerGameApp/CardDeck.swift
+++ b/PokerGameApp/PokerGameApp/CardDeck.swift
@@ -33,4 +33,8 @@ struct CardDeck {
         }
     }
     
+    mutating func removeOne() -> Card? {
+        return cards.popLast()
+    }
+    
 }

--- a/PokerGameApp/PokerGameApp/CardDeck.swift
+++ b/PokerGameApp/PokerGameApp/CardDeck.swift
@@ -1,0 +1,12 @@
+//
+//  CardDeck.swift
+//  PokerGameApp
+//
+//  Created by PJB on 2023/03/22.
+//
+
+import Foundation
+
+struct cardDeck {
+    
+}

--- a/PokerGameApp/PokerGameApp/CardDeck.swift
+++ b/PokerGameApp/PokerGameApp/CardDeck.swift
@@ -26,4 +26,11 @@ struct CardDeck {
         self.newCards = self.cards
     }
     
+    mutating func shuffle() {
+        for cardIndex in 0..<cardCount-1 {
+            let randomIndex = Int.random(in: cardIndex..<cardCount)
+            cards.swapAt(cardIndex, randomIndex)
+        }
+    }
+    
 }

--- a/PokerGameApp/PokerGameApp/CardDeck.swift
+++ b/PokerGameApp/PokerGameApp/CardDeck.swift
@@ -7,6 +7,13 @@
 
 import Foundation
 
-struct cardDeck {
+struct CardDeck {
+    
+    private var cards: [Card]
+    private let newCards: [Card]
+    
+    var cardCount: Int {
+        return cards.count
+    }
     
 }

--- a/PokerGameApp/PokerGameApp/CardDeck.swift
+++ b/PokerGameApp/PokerGameApp/CardDeck.swift
@@ -37,4 +37,7 @@ struct CardDeck {
         return cards.popLast()
     }
     
+    mutating func reset() {
+        self.cards = self.newCards
+    }
 }

--- a/PokerGameApp/PokerGameApp/ViewController.swift
+++ b/PokerGameApp/PokerGameApp/ViewController.swift
@@ -21,7 +21,7 @@ class ViewController: UIViewController {
         self.view.backgroundColor = UIColor(patternImage: image)
     }
     private func setCardBack(cardCount: Int) {
-        var positionX: CGFloat = 2.5
+        var positionX: CGFloat = 2
         let positionY: CGFloat = 59
         let spacing: CGFloat = 2.5
         let spaceCount: CGFloat = 8

--- a/PokerGameApp/PokerGameApp/ViewController.swift
+++ b/PokerGameApp/PokerGameApp/ViewController.swift
@@ -15,6 +15,7 @@ class ViewController: UIViewController {
         setCardBack(cardCount: 7)
         let oneCard = Card(suit: .spades, rank: .queen)
         print(oneCard)
+        printTestScenario()
     }
     private func setBackground() {
         guard let image = UIImage(named: "bg_pattern") else { return }
@@ -37,5 +38,22 @@ class ViewController: UIViewController {
             view.addSubview(cardImageView)
             positionX += cardWidth + spacing
         }
+    }
+    private func printTestScenario() {
+        var testScenario = CardDeck()
+        
+        print("카드 초기화")
+        testScenario.reset()
+        print("총 \(testScenario.cardCount)장의 카드가 있습니다")
+        
+        print("카드 섞기")
+        testScenario.shuffle()
+        print("전체 \(testScenario.cardCount)장의 카드를 섞었습니다")
+        
+        guard let testCard = testScenario.removeOne() else { return }
+        
+        print("카드 하나 뽑기")
+        print("\(testCard)")
+        print("총 \(testScenario.cardCount)장의 카드가 남아있습니다")
     }
 }

--- a/README.md
+++ b/README.md
@@ -16,4 +16,20 @@
 - [x] 카드 정보를 출력하기 위한 문자열을 반환하는 함수를 구현하기
 - [x] 클래스 이름, 변수 이름, 함수 이름에서 자신만의 규칙 먄들기
 - [x] 유니코드에 대해 학습하기
-- [ ] 객체지향 프로그래밍(Object-oriented Programming) 방식에 대해 학습하기
+<img width="582" alt="스크린샷 2023-03-21 오후 4 25 35" src="https://user-images.githubusercontent.com/115064144/227180477-a4e96c71-fbe1-4219-8e43-b7cac4ae21c9.png">
+
+## 3. 카드덱 구현하고 테스트하기
+- [x] 앞에서 구현한 모든 종류의 Card 인스턴스를 포함하는 CardDeck 구조체 구현하기
+- [x] count를 가지고 있는 카드 개수 반환
+- [x] shuffle 메서드 구현
+- [x] removeOne 메서드 구현
+- [x] reset 메서드 구현
+- [x] 예상 결과를 호출하고 출력하는 테스트 시나리오 구현
+<img width="611" alt="스크린샷 2023-03-23 오후 7 03 13" src="https://user-images.githubusercontent.com/115064144/227180613-9970226b-6a92-4663-92b2-acc8b21c5f6f.png">
+
+## 4. 게임 로직 구현하기
+- [ ] 카드 덱을 활용해서 카드를 나눠주는 Dealer 설계
+- [ ] 카드를 받는 Participant 설계
+- [ ] Dealer와 Participant를 포함하는 PokerGame 객체 작성
+- [ ] XCTest 단위 테스트 구현
+- [ ] 참가자 이름 랜덤하게 설정하는 로직 구현하기


### PR DESCRIPTION
# 작업내용
- #43 피드백 반영
- CardDeck 구조체 생성
- shuffle() 메서드 구현
- removeOne() 메서드 구현
- reset() 메서드 구현

# 스크린샷
<img width="611" alt="스크린샷 2023-03-23 오후 7 03 13" src="https://user-images.githubusercontent.com/115064144/227199714-59d6ef9f-a56b-4c30-932f-d90581b89686.png">

# 학습
- Fisher-Yates Shuffle & Knuth Shuffle
- caseIterable
- popLast()
- Optional

# 고민했던 부분과 해결 과정
### 첫번째 고민 : reset() 과 init()
- 3/22일 멘토링 시간에도 말씀 해주신 부분을 생각해보며 고민하였습니다
1. 두 메소드의 기능이 동일하기 때문에 공통적인 부분을 또 다른 하나의 메소드로 구현하여, 각자의 메소드 내부에서 호출을 해야하는가?
2. 아니면 reset()에서 공통적인 부분을 구현하고 init()에서 호출을 해야 하는가?
3. 지난 멘토링 시간 때 본 self = Self.init() 을 사용하여 처리 해야 하는가? 등등
- 결국 비슷한 고민거리지만, '어떻게 해야 보다 괜찮게 처리할 수 있을까' 라는 생각을 많이 하였습니다
- 그래서 `private let newCards: [Card]` 을 선언하여 새로운 배열을 기존 `cards`에 복사하는 방법을 생각하였습니다
- 아직 이 방법이 더 괜찮은 방법인지는 확신이 들지 않습니다

### 두번째 고민 : 이게 reset() 이 맞을까?
- 위의 고민과 이어지는데, 위에서 생각한 방법이 `reset()` 이라는 메서드보다 `change()` 라는 이름의 메서드가 더 잘 어울리겠다 라고 생각하였습니다
- 메서드명을 뱌꿀까 생각했지만, 결과적으로는 리셋이 되기 때문에 변경하지는 않았습니다

### 세번째 고민 : shuffle() 메서드 구현
- 이미 뽑혔던 요소가 다시 뽑히는 일이 생기면 안되니, 반복문과 Int.random 그리고 swap() 메소드를 사용하여 목적에 맞게 잘 shuffle 되도록 구현해 보았습니다
- https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle